### PR TITLE
Fix typo in currentSessionPicUrlAtom

### DIFF
--- a/src/renderer/components/Message.tsx
+++ b/src/renderer/components/Message.tsx
@@ -20,7 +20,7 @@ import {
     openSettingDialogAtom,
     enableMarkdownRenderingAtom,
 } from '../stores/atoms'
-import { currsentSessionPicUrlAtom, showTokenUsedAtom } from '../stores/atoms'
+import { currentSessionPicUrlAtom, showTokenUsedAtom } from '../stores/atoms'
 import * as scrollActions from '../stores/scrollActions'
 import Markdown from '@/components/Markdown'
 import '../static/Block.css'
@@ -51,7 +51,7 @@ export default function Message(props: Props) {
     const showWordCount = useAtomValue(showWordCountAtom)
     const showTokenUsed = useAtomValue(showTokenUsedAtom)
     const enableMarkdownRendering = useAtomValue(enableMarkdownRenderingAtom)
-    const currentSessionPicUrl = useAtomValue(currsentSessionPicUrlAtom)
+    const currentSessionPicUrl = useAtomValue(currentSessionPicUrlAtom)
     const setOpenSettingWindow = useSetAtom(openSettingDialogAtom)
 
     const { msg, className, collapseThreshold, hiddenButtonGroup, small } = props

--- a/src/renderer/stores/atoms.ts
+++ b/src/renderer/stores/atoms.ts
@@ -94,7 +94,7 @@ export const currentSessionAtom = atom((get) => {
 })
 
 export const currentSessionNameAtom = selectAtom(currentSessionAtom, (s) => s.name)
-export const currsentSessionPicUrlAtom = selectAtom(currentSessionAtom, (s) => s.picUrl)
+export const currentSessionPicUrlAtom = selectAtom(currentSessionAtom, (s) => s.picUrl)
 
 
 export const currentMessageListAtom = selectAtom(currentSessionAtom, (s) => {


### PR DESCRIPTION
## Summary
- fix variable name `currsentSessionPicUrlAtom`
- update imports in `Message.tsx`

## Testing
- `npm run lint` *(fails: Invalid property "node")*